### PR TITLE
Openstack doc format fix

### DIFF
--- a/openstack/doc/Deploy_manual.md
+++ b/openstack/doc/Deploy_manual.md
@@ -1,5 +1,5 @@
-1. [Setup Deployment Environment](#1)
-2. [Deploy OpenStack](#2)
+* [1. Setup Deployment Environment](#1)
+* [2. Deploy OpenStack](#2)
 
 ## Terms
 **Deployment machine**: machine to run deployment scripts.

--- a/openstack/doc/OpenStack_Manual.md
+++ b/openstack/doc/OpenStack_Manual.md
@@ -1,6 +1,11 @@
-# Introduction
-This is the OpenStack manual. It contains deploy manual and End user manual.
+* [Introduction](#1)
+* [Deployment Manual](#2)
+* [End User Manual](#3)
 
-# [Deploy Manual](Deploy_manual.md)
+## <a name="1">Introduction</a>
+This is the OpenStack manual. It contains deployment manual and End user manual.
 
-# [End User Manual](End_user_manual.md)
+## <a name="2">[Deployment Manual](Deploy_manual.md)</a>
+
+## <a name="3">[End User Manual](End_user_manual.md)</a>
+


### PR DESCRIPTION
Fix OpenStack_Manual.md and Deploy_manual.md format, make the format look the same as other package's manual.